### PR TITLE
Change the default size of the contained elements the List combinator…

### DIFF
--- a/lib/Test/LectroTest/Generator.pm
+++ b/lib/Test/LectroTest/Generator.pm
@@ -436,7 +436,7 @@ sub List(@) {
     my $template = _template(@_);
     my $builder = sub {
         my ($len, $size) = @_;
-        my $subsize = defined $size ? $size / ($len+1) : 1;
+        my $subsize = defined $size ? $size / ($len+1) : undef;
         my @list;
         foreach (1..$len) {
             foreach my $generator (@$template) {


### PR DESCRIPTION
Hi Tom,

I may have misunderstood as this is the very first use of LectroTest I have made. I wrote the following 

``` perl
use Test::LectroTest::Generator qw(:common :combinators);
use Data::Dumper;

my $byte = Int( range => [0, 255] );
my $cidr = Int( range => [0, 32] );
my $address = Paste( ($byte) x 4, glue => "." );
my $address_range = Paste( $address, $cidr, glue => "/" );

for my $i (1..3) {
    print $address_range->generate() . "\n"; 
}
```

I expected this to produce 

```
126.203.112.176/25
131.77.191.23/22
150.241.41.114/9
```

however what I got was 

```
0.0.0.0/0
0.0.0.0/1
0.0.0.0/0
```

With the change I have made I get the expected result, also all the tests still pass.

Regards
Joe
